### PR TITLE
feat: added get APIs to fetch swamp info

### DIFF
--- a/backend/controllers/swamp_controller.go
+++ b/backend/controllers/swamp_controller.go
@@ -3,8 +3,11 @@ package controllers
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"swamp/database"
 	"swamp/models"
+
+	"github.com/go-chi/chi/v5"
 )
 
 // CreateSwamp handles the creation of a new swamp
@@ -37,3 +40,51 @@ func CreateSwamp(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
+
+
+func GetSwamps(w http.ResponseWriter, r *http.Request) {
+	pageNumber, _ := strconv.Atoi(r.URL.Query().Get("pageNumber"))
+	recordsPerPage, _ := strconv.Atoi(r.URL.Query().Get("recordsPerPage"))
+	if pageNumber < 1 { 
+		pageNumber = 1
+	}
+	if recordsPerPage < 1 {
+		recordsPerPage = 10
+	}
+	var swamps []models.Swamp
+	var totalResults int64 
+	database.DB.Model(&models.Swamp{}).Count(&totalResults)
+	database.DB.Limit(recordsPerPage).Offset((pageNumber - 1) * recordsPerPage).Find(&swamps)
+
+
+	response := map[string]interface{}{
+		"meta":map[string]int{
+			"totalResults": int(totalResults),
+			"pageNumber": pageNumber,
+			"recordsPerPage": recordsPerPage,
+		},
+		"allDocuments": swamps,
+	}
+	
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+
+func GetSwampByID(w http.ResponseWriter, r *http.Request) {
+	swampIDStr := chi.URLParam(r, "id")
+	swampID, _ := strconv.Atoi(swampIDStr)
+	var swamp models.Swamp
+	if err:= database.DB.First(&swamp, "id=?", swampID).Error; err != nil{
+		http.Error(w, "Swamp not found % v", http.StatusNotFound)
+		return 
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(swamp)
+}
+
+
+
+
+

--- a/backend/database/db.go
+++ b/backend/database/db.go
@@ -19,7 +19,7 @@ func ConnectDB() *gorm.DB {
 		log.Fatal("Failed to connect to the database:", err)
 	}
 
-	AutoMigrate all models
+	//AutoMigrate all models
 	err = db.AutoMigrate(&models.User{}, &models.OTP{}, &models.Swamp{})
 	if err != nil {
 		log.Fatalf("Failed to migrate database %v:", err)

--- a/backend/database/db.go
+++ b/backend/database/db.go
@@ -13,7 +13,7 @@ var DB *gorm.DB // Global variable to hold the database connection
 
 // ConnectDB initializes the PostgreSQL database connection
 func ConnectDB() *gorm.DB {
-	dsn := "host=localhost user=postgres dbname=postgres password=swamp port=5432 sslmode=disable"
+	dsn := "host=localhost user=postgres dbname=postgres password=swamp port=5433 sslmode=disable"
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
 		log.Fatal("Failed to connect to the database:", err)

--- a/backend/database/db.go
+++ b/backend/database/db.go
@@ -3,7 +3,7 @@ package database
 import (
 	"fmt"
 	"log"
-	// "swamp/models"
+	"swamp/models"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"

--- a/backend/database/db.go
+++ b/backend/database/db.go
@@ -3,7 +3,7 @@ package database
 import (
 	"fmt"
 	"log"
-	"swamp/models"
+	// "swamp/models"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -19,10 +19,10 @@ func ConnectDB() *gorm.DB {
 		log.Fatal("Failed to connect to the database:", err)
 	}
 
-	// AutoMigrate all models
+	AutoMigrate all models
 	err = db.AutoMigrate(&models.User{}, &models.OTP{}, &models.Swamp{})
 	if err != nil {
-		log.Fatal("Failed to migrate database:", err)
+		log.Fatalf("Failed to migrate database %v:", err)
 	}
 
 	DB = db // Assign database instance to the global DB variable

--- a/backend/routers/routes.go
+++ b/backend/routers/routes.go
@@ -20,4 +20,7 @@ func SetupRoutes(r *chi.Mux) {
 
 	// Swamp routes
 	r.Post("/api/swamp", controllers.CreateSwamp)
+	r.Get("/api/swamp", controllers.GetSwamps)
+	r.Get("/api/swamp/{id}", controllers.GetSwampByID)
+
 }


### PR DESCRIPTION
In this PR: 

I have introduced two endpoints, 
1. Fetch a list of swamps (introduced pagination:  pageNumber and recordsPerPage)
2. Fetch a swamp by its ID
3. Added test cases to check the functionality. 

Tested the feature manually using Postman. 